### PR TITLE
Resolved error that lint message is invalid due to not having name

### DIFF
--- a/src/linters/ArcanistScalastyleLinter.php
+++ b/src/linters/ArcanistScalastyleLinter.php
@@ -62,7 +62,8 @@ final class ArcanistScalastyleLinter extends ArcanistExternalLinter {
     foreach ($lines as $line) {
       $lintMessage = id(new ArcanistLintMessage())
         ->setPath($path)
-        ->setCode($this->getLinterName());
+        ->setCode($this->getLinterName())
+        ->setName($this->getLinterName());
 
       $matches = array();
       if (preg_match('/^([a-z]+)/', $line, $matches)) {


### PR DESCRIPTION
On newest arcanist I got the following error:

`Linter "ArcanistScalastyleLinter" generated a lint message that is invalid because it does not have a name. Lint messages must have a name.`

This PR resolves this issue.
