### PR TITLE
Fix issue #4 ArcanistScalastyleLinter

### DIFF
--- a/src/linters/ArcanistScalastyleLinter.php
+++ b/src/linters/ArcanistScalastyleLinter.php
@@ -41,7 +41,7 @@ final class ArcanistScalastyleLinter extends ArcanistExternalLinter {
 
     return array(
       '--config', $this->configPath,
-      '--quiet', 'true');
+      '--quiet', 'false');
   }
 
   protected function getDefaultFlags() {
@@ -98,7 +98,8 @@ final class ArcanistScalastyleLinter extends ArcanistExternalLinter {
         $lintMessage->setChar(trim($matches[1]));
       }
 
-      $messages[] = $lintMessage;
+      if ($lintMessage->getSeverity() != NULL)
+        $messages[] = $lintMessage;
     }
 
     return $messages;


### PR DESCRIPTION
In scalastyle 0.8.0, option '--quiet true' consumes all the output (including lints), and for some reason, a NULL is passed as the last line while parsing messages, this commit fix these issues.
